### PR TITLE
Fix: Add missing alif maksura (ى) character mapping

### DIFF
--- a/src/Mapping/IraqMapping.php
+++ b/src/Mapping/IraqMapping.php
@@ -311,7 +311,7 @@ class IraqMapping extends BaseMapping
             'ظ' => 'dh','ع' => 'a', 'غ' => 'gh',
             'ف' => 'f', 'ق' => 'q', 'ك' => 'k',
             'ل' => 'l', 'م' => 'm', 'ن' => 'n',
-            'ه' => 'h', 'و' => 'w', 'ي' => 'y',
+            'ه' => 'h', 'و' => 'w', 'ي' => 'y', 'ى' => 'a',
 
             // Extra Persian letters (used in some Iraqi contexts)
             'چ' => 'ch', // e.g., "چاي" → "chai"

--- a/tests/TransliteratorTest.php
+++ b/tests/TransliteratorTest.php
@@ -199,7 +199,7 @@ class TransliteratorTest extends TestCase
         return [
             'Full Iraqi name' => ['محمد عبد الرحمن العبد الله', 'Muhammad Abd Al-Rahman Alabd Al-lh'],
             'Name with diacritics' => ['مُحَمَّد عَلِيّ', 'Mhmd Aly'],
-            'Multi-word name partially in dictionary' => ['نور الهدى محمد علي', 'Noor Alhdى Muhammad Ali'],
+            'Multi-word name partially in dictionary' => ['نور الهدى محمد علي', 'Noor Alhda Muhammad Ali'],
         ];
     }
 


### PR DESCRIPTION
- Add mapping for ى (alif maksura) to 'a' in IraqMapping letter map
- Fix transliteration of words ending with ى (e.g., نينوى -> Nynwa)
- Update test expectation to reflect correct behavior
- Resolves issue where ى character was not being transliterated

Fixes transliteration for words like:
- نينوى (Nineveh)
- موسى (Musa)
- ليلى (Layla)
- هدى (Huda)